### PR TITLE
fix: plugin scanner : changed bootstrap.php to Bootstrap.php && add .sync to replaces

### DIFF
--- a/project/packages/plugin/scanner.js
+++ b/project/packages/plugin/scanner.js
@@ -68,7 +68,7 @@ class Scanner {
     async searchReplace( data, projectPath ) {
         const phpFiles         = [
             path.join( projectPath, 'the-plugin-name.php' ),
-            path.join( projectPath, 'src', 'bootstrap.php' ),
+            path.join( projectPath, 'src', 'Bootstrap.php' ),
             path.join( projectPath, 'src', 'App', '**', '*.php' ),
             path.join( projectPath, 'src', 'Common', '**', '*.php' ),
             path.join( projectPath, 'src', 'Compatibility', '**', '*.php' ),
@@ -88,7 +88,7 @@ class Scanner {
         const travisCiFiles    = [
             path.join( projectPath, '.travis.yml' ),
         ];
-        const bootstrapFile    = path.join( projectPath, 'src', 'bootstrap.php' );
+        const bootstrapFile    = path.join( projectPath, 'src', 'Bootstrap.php' );
         const composerFile     = path.join( projectPath, 'composer.json' );
         const pathEntryFile    = path.join( projectPath, `the-plugin-name.php` );
 

--- a/project/packages/plugin/scanner.js
+++ b/project/packages/plugin/scanner.js
@@ -34,7 +34,7 @@ class Scanner {
      * @returns {Promise<*>}
      */
     async replacer( files, from, to, pathToFolder ) {
-        return replace( {
+        return replace.sync( {
             files:  files,
             from:   from,
             to:     to,


### PR DESCRIPTION
There is a problem with the name of the boostrap.php file. 

Doing some testing, I noticed that the marks placed in the various files are not being replaced, even after making the above change. 

By making the method synchronous, the problem on windows was solved. 
